### PR TITLE
[bugfix] Fixed host filtering when using a parent proxy

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
 pytest
-pytest-cov==2.10.1
-ddt==1.4.1
+pytest-cov
+ddt
 requests[socks]

--- a/tests/unit/test_tcp_upstream.py
+++ b/tests/unit/test_tcp_upstream.py
@@ -1,0 +1,33 @@
+import unittest
+from yew.modules.tcp.upstreams import TCPUpStream, ParentUpStream, ForbiddenHostError
+
+
+class TCPUpStreamTestCase(unittest.TestCase):
+
+	def test_filtering_allow(self):
+		upstream = TCPUpStream("test", {"allow": ["abc.com", "^def.net"]})
+		self.assertTrue(upstream.can_connect_host("www.abc.com"))
+		self.assertTrue(upstream.can_connect_host("def.net"))
+		self.assertFalse(upstream.can_connect_host("www.def.net"))
+		self.assertFalse(upstream.can_connect_host("www.google.com"))
+
+	def test_filtering_disallow(self):
+		upstream = TCPUpStream("test", {"disallow": ["abc.com", "^def.net"]})
+		self.assertFalse(upstream.can_connect_host("www.abc.com"))
+		self.assertFalse(upstream.can_connect_host("def.net"))
+		self.assertTrue(upstream.can_connect_host("www.def.net"))
+		self.assertTrue(upstream.can_connect_host("www.google.com"))
+
+	def test_filtering_cannot_use_both(self):
+		with self.assertRaises(ValueError):
+			TCPUpStream("test", {"disallow": ["abc.com"], "allow": ["^def.net"]})
+
+	def test_TCPUpStream_open_connection_forbidden(self):
+		upstream = TCPUpStream("test", {"disallow": ["abc.com", "^def.net"]})
+		with self.assertRaises(ForbiddenHostError):
+			upstream.open_connection(None, "abc.com", 443)
+
+	def test_ParentUpStream_open_connection_forbidden(self):
+		upstream = ParentUpStream("test", {"disallow": ["abc.com", "^def.net"]})
+		with self.assertRaises(ForbiddenHostError):
+			upstream.open_connection(None, "abc.com", 443)

--- a/tests/unit/test_tcp_upstream.py
+++ b/tests/unit/test_tcp_upstream.py
@@ -1,5 +1,8 @@
 import unittest
-from yew.modules.tcp.upstreams import TCPUpStream, ParentUpStream, ForbiddenHostError
+from yew.modules.tcp.upstreams import (
+	TCPUpStream, ParentUpStream, ForbiddenHostError,
+	BindDeviceError, BindIPError, GAIError
+)
 
 
 class TCPUpStreamTestCase(unittest.TestCase):
@@ -31,3 +34,18 @@ class TCPUpStreamTestCase(unittest.TestCase):
 		upstream = ParentUpStream("test", {"disallow": ["abc.com", "^def.net"]})
 		with self.assertRaises(ForbiddenHostError):
 			upstream.open_connection(None, "abc.com", 443)
+
+	def test_create_socket_bind_device_fails(self):
+		upstream = ParentUpStream("test", {})
+		with self.assertRaises(BindDeviceError):
+			upstream.create_socket(None, "abc.com", 443, bind_device="not_existing_device")
+
+	def test_create_socket_bind_ip_fails(self):
+		upstream = ParentUpStream("test", {})
+		with self.assertRaises(BindIPError):
+			upstream.create_socket(None, "abc.com", 443, bind_ip="200.0.0.0")
+
+	def test_create_socket_gai_error(self):
+		upstream = ParentUpStream("test", {})
+		with self.assertRaises(GAIError):
+			upstream.create_socket(None, "not-existing.www", 443)

--- a/yew/modules/http/servers.py
+++ b/yew/modules/http/servers.py
@@ -82,9 +82,9 @@ class Proxy(TCPServer):
 				info.server.logger.info(str(request))
 				psock, pinfo = info.server.get_upstream(request).open_connection(
 					info.server, *request.getHostPort())
-			except ForbiddenHostError:
+			except ForbiddenHostError as e:
 				self.write_output(HTTP_FORBIDDEN_HOST, sock, info)
-				info.server.logger.info("requested forbidden host.")
+				info.server.logger.info(f"Requested forbidden host: {e}.")
 			except UpStreamError:
 				self.write_output(HTTP_BAD_GATEWAY, sock, info)
 				info.server.logger.exception("upstreamerror")

--- a/yew/modules/socks5/proxy.py
+++ b/yew/modules/socks5/proxy.py
@@ -82,8 +82,8 @@ class Proxy(TCPServer):
 			try:
 				psock, pinfo = self.get_upstream(ConnectRequest).open_connection(
 					info.server, request.host, request.port)
-			except ForbiddenHostError:
-				info.server.logger.warning("Forbidden host {}".format(request.host))
+			except ForbiddenHostError as e:
+				info.server.logger.info(f"Requested forbidden host: {e}.")
 				self.final_message(
 					ConnectResponse.error(SOCKS5_REPLY_NOT_ALLOWED), sock, info)
 			except GAIError:

--- a/yew/modules/tcp/upstreams.py
+++ b/yew/modules/tcp/upstreams.py
@@ -36,7 +36,7 @@ class TCPUpStream(UpStream):
 			- ForbiddenHostError: Connections to this host are not allowed.
 		"""
 		if not self.can_connect_host(host):
-			raise ForbiddenHostError()
+			raise ForbiddenHostError(host)
 		else:
 			return self.create_socket(server, host, port, bind_device, bind_ip)
 
@@ -144,7 +144,7 @@ class ParentUpStream(TCPUpStream):
 			- ForbiddenHostError: Connections to this host are not allowed.
 		"""
 		if not self.can_connect_host(host):
-			raise ForbiddenHostError()
+			raise ForbiddenHostError(host)
 		else:
 			sock, info = self.create_socket(server, self.parent_host, self.parent_port, 
 				bind_device, bind_ip)


### PR DESCRIPTION
Changes:
- Fixed host filtering in tcp.upstream.ParentUpStream.
- Added test cases for module tcp.upstream.